### PR TITLE
Adds support for arbitrary zones (fixes #5).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Environment variables:
 When `PUBLIC_IP` is not defined, call AWS's EC2 metadataservice to get it.
 When AWS EC2 metadata service is not present; call icanhazip.com.
 
-When `PRIVATE_TOP_ZONES` is not defined its default value is: `localhost local priv private`
-When the VIRTUAL_HOST matches such a domain or hostname it is not published on route53.
+When `PRIVATE_TOP_ZONES` is not defined it defaults to: `localhost local priv private`
+When the `VIRTUAL_HOST` matches such a domain or hostname it is not published on route53.
 
-The zone is assumed to be of the form yyy.zzz (e.g. example.com). If you use
-subdomains you can supply a ZONE environmental variable to specify the
-appropriate value. For instance, if you want to create foo.at.example.com,
-specify a ZONE of at.example.com.
+When `ZONE` is not defined it defaults to the domain of `VIRTUAL_HOST`.
+To use `VIRTUAL_HOST` on subdomains, set the `ZONE`. For example:
+
+    `VIRTUAL_HOST=foo.at.example.com` and `ZONE=at.example.com`
+    `VIRTUAL_HOST=foo.example.com` (`ZONE` defaults to example.com)
 
 Example run
 ===========

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ When AWS EC2 metadata service is not present; call icanhazip.com.
 When `PRIVATE_TOP_ZONES` is not defined its default value is: `localhost local priv private`
 When the VIRTUAL_HOST matches such a domain or hostname it is not published on route53.
 
+The zone is assumed to be of the form yyy.zzz (e.g. example.com). If you use
+subdomains you can supply a ZONE environmental variable to specify the
+appropriate value. For instance, if you want to create foo.at.example.com,
+specify a ZONE of at.example.com.
+
 Example run
 ===========
 ```
@@ -58,6 +63,11 @@ web00:
   image: progrium/webapp
   environment:
     VIRTUAL_HOST: localhost,dev01.foo.bar
+web01:
+  image: progrium/webapp2
+  environment:
+    VIRTUAL_HOST: localhost,dev01.a.foo.bar
+    ZONE: a.foo.bar
 ```
 
 Example generated script:

--- a/cli53routes.tmpl
+++ b/cli53routes.tmpl
@@ -3,11 +3,20 @@
 [ -z "$PUBLIC_IP" -o "not found" = "$PUBLIC_IP" ] && PUBLIC_IP=`curl -s icanhazip.com`
 [ -z "$PRIVATE_TOP_ZONES" ] && PRIVATE_TOP_ZONES="localhost local priv private"
 
+{{ range $zone, $containers := groupByMulti $ "Env.ZONE" "," }}
+zone={{ $zone }}
+{{ end }}
+
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 host={{ $host }}
 topzone=$(echo "${host##*.}")
-tenant=$(echo "${host%.*.*}")
-zone=$(echo "${host#$tenant.}")
+
+if [ -n "$zone" ]; then
+  tenant=$(echo "${host%.$zone}")
+else
+  tenant=$(echo "${host%.*.*}")
+  zone=$(echo "${host#$tenant.}")
+fi
 if [ "${PRIVATE_TOP_ZONES#*$topzone}" != "$PRIVATE_TOP_ZONES" -o "$tenant" = "$zone" ]; then
 	echo "Skipping private hostname $host" >> /var/log/route53-dyndns.log
 else


### PR DESCRIPTION
This adds support for the ZONE environmental variable. I tested this for normal `example.com` and subdomained zones `at.example.com`.